### PR TITLE
bugfix: 与Typecho上游对齐

### DIFF
--- a/layout/_partial/paginator.php
+++ b/layout/_partial/paginator.php
@@ -1,14 +1,5 @@
-<?php 
+<?php
 $this->pageNav(
-    '<','>', 2, '...', 
-     array(
-        'wrapTag' => 'nav',
-        'wrapClass' => 'nexmoe-page-nav', 
-        'itemTag' => '', 
-        'textTag' => 'a', 
-        'currentClass' => 'page-number current', 
-        'prevClass' => 'extend prev', 
-        'nextClass' => 'extend next',
-    )
+    '<','>', 2, '...', 'wrapTag=nav&wrapClass=nexmoe-page-nav&itemTag=&textTag=a&currentClass=page-number current&prevClass=extend prev&nextClass=extend next'
 );
 ?>


### PR DESCRIPTION
[layout]paginator: Upstream to fix pageNav()

Upstream changes of typecho forced the 5th parameter 'template' of pageNav() function to be string type.
Array type will no longer be used.

Errors: Argument 5 passed to Widget\Archive::pageNav() must be of the type string, array given, called in /home/wwwroot/lnmp01/domain/blog.kmou424.moe/web/usr/themes/nexmoe/layout/_partial/paginator.php on line 5
Changes: https://github.com/typecho/typecho/commit/7a1b74b351a2570540ab7381871d6937b7c02f02#diff-bdc2538791420cbaa1c9a2c5b9c262a5d20c5db5e0294834f55c40c6d1e691bcR794

Signed-off-by: kmou424 <me@kmou424.moe>